### PR TITLE
fix: options handling

### DIFF
--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -1,3 +1,13 @@
 export default {
-  buildModules: ['../src/module.ts']
+  buildModules: ['../src/module.ts'],
+  motion: {
+    test: {
+      motion: 1,
+    }
+  },
+  motions: {
+    test: {
+      motions: 1,
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@nuxtjs/composition-api": "^0.20.2",
     "@vueuse/motion": "^1.0.5",
-    "defu": "^2.0.4",
+    "defu": "^3.2.2",
     "vue-demi": "^0.6.0"
   },
   "devDependencies": {

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,10 +13,12 @@ export interface ModuleOptions {
 const DEFAULTS: ModuleOptions = {}
 
 const CONFIG_KEY = 'motion'
+const CONFIG_KEY2 = 'motions'
 
 const nuxtModule: Module<ModuleOptions> = async function (moduleOptions) {
-  const options = defu<ModuleOptions>(
-    this.options[CONFIG_KEY],
+  const options: ModuleOptions = defu(
+    this.options[CONFIG_KEY]!,
+    this.options[CONFIG_KEY2]!,
     moduleOptions,
     DEFAULTS
   )
@@ -24,13 +26,15 @@ const nuxtModule: Module<ModuleOptions> = async function (moduleOptions) {
   this.addTemplate({
     fileName: 'motion.config.js',
     src: resolve(__dirname, '../templates', 'motion.config.js'),
-    options,
   })
 
   this.addPlugin({
     src: resolve(__dirname, '../templates', 'motion.js'),
     fileName: 'motion.js',
+    options,
   })
+
+  this.nuxt.options.build.transpile.push('defu')
 
   await this.addModule('@nuxtjs/composition-api')
 }
@@ -40,9 +44,13 @@ const nuxtModule: Module<ModuleOptions> = async function (moduleOptions) {
 declare module '@nuxt/types' {
   interface NuxtConfig {
     [CONFIG_KEY]?: ModuleOptions
+    /**@deprecated use motion option instead */
+    [CONFIG_KEY2]?: ModuleOptions
   } // Nuxt 2.14+
   interface Configuration {
     [CONFIG_KEY]?: ModuleOptions
+    /**@deprecated use motion option instead */
+    [CONFIG_KEY2]?: ModuleOptions
   } // Nuxt 2.9 - 2.13
 }
 

--- a/templates/motion.js
+++ b/templates/motion.js
@@ -1,7 +1,8 @@
 import { MotionPlugin } from '@vueuse/motion'
 import Vue from 'vue'
-import userOptions from './motion.config'
+import defu from 'defu'
+import appOptions from './motion.config'
 
-const options = Object.assign(<%= JSON.stringify(options) %>, userOptions)
+const options = defu(appOptions, <%= JSON.stringify(options, null, 2) %>)
 
 Vue.use(MotionPlugin, options)


### PR DESCRIPTION
Following up #3:
- Add back support of `motions` option since in a same semver-major (v1) we should not add breaking changes
- Fix passing `options` to correct template
- Use defu for deep merging options